### PR TITLE
Add `--frozen-lockfile` to `yarn install` commands

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,5 +23,5 @@ jobs:
       run: |
         git config --global user.name 'Rancher Icons'
         git config --global user.email 'noreply@rancher.com'
-        yarn install
+        yarn install --frozen-lockfile
         yarn run upload -i


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates yarn install usage to enforce `--frozen-lockfile` across all `yarn` and `yarn install` commands.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `--frozen-lockfile` to yarn install commands

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`--frozen-lockfile` makes installs deterministic by ensuring that yarn installs the exact dependency versions already defined in `yarn.lock`. If the lockfile is out of sync with `package.json`, the install fails immediately instead of silently re-resolving dependencies or mutating the lockfile. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI should pass without failure.

### Related work

- https://github.com/rancher/dashboard/pull/17101
