### PR TITLE
Change to NPM, change to hardcode NPM_REGISTRY, change to use same PUBLISH_ARGS as the shell

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -66,14 +66,16 @@ fi
 if [ -n "${NODE_AUTH_TOKEN}" ]; then
   echo "Publishing @rancher/icons to npm"
 
+  # Hardcode the registry to match the shell publish pattern
+  NPM_REGISTRY="https://registry.npmjs.org"
+  PUBLISH_ARGS="--no-git-tag-version --access public --registry $NPM_REGISTRY"
+
   pwd
   pushd ${DIST}
   pwd
   ls -al
-  
-  PUBLISH_ARGS="--no-git-tag-version --access public"
 
-  yarn publish . --new-version ${VERSION} ${PUBLISH_ARGS}
+  npm publish . ${PUBLISH_ARGS}
   RET=$?
 
   popd


### PR DESCRIPTION
https://github.com/rancher/icons/actions/runs/25493619683

Workflow seems to be failing after the changes to the version node v14 to v24.
To fix that we updated the script to follow the same as the SHELL

We updated the script to use NPM PUBLISH instead of YARN PUBLISH.
We used the same ARGs as the one from SHELL
We hardcoded the REGISTRY as well, same as the SHELL publish script is doing.