### PR TITLE
Release/v2.0.60

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup publish
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -31,7 +30,7 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Run publish script     
+      - name: Run publish script
         run: |
           git config --global user.name 'Rancher Icons'
           git config --global user.email 'noreply@rancher.com'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Tracks icons added/removed.
 
 | Version | Note                                                                            |
 | ------- | ------------------------------------------------------------------------------- |
+| 2.0.60  | Update github publishing credentials                                            |
 | 2.0.59  | Configure trusted publishing                                                    |
 | 2.0.58  | Update publish.sh to use npm, update package config                             |
 | 2.0.57  | Adds icons for vm migration tool in Harvester - disk, network, data, arrow      |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/icons",
-  "version": "2.0.59",
+  "version": "2.0.60",
   "description": "Rancher icon font",
   "repository": "https://github.com/rancher/icons",
   "scripts": {


### PR DESCRIPTION
#104 added the line for `persist-credentials: false`, which might be preventing the github token from being accessed later in the publishing script. `contents: write` will also be required for the git operations at the end of `publish.sh`.
