### PR TITLE
Add CODEOWNERS pointing at the Rancher UI owners list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This repository is owned by the Rancher UI team.
+#
+# Owners are deliberately NOT declared here.
+#
+# The canonical list of Rancher UI repositories and their owning teams lives in:
+#   https://github.com/rancher/dashboard/blob/master/.github/OWNERS.md
+#
+# To find out who to contact about this repository, see that file.


### PR DESCRIPTION
Adds a `CODEOWNERS` file for this repository.

The file contains only comments. GitHub automatically requests a review from
every code owner matched by a pull request and that cannot be disabled, so
declaring owner rules here would generate review requests the team cannot act
on. A comments-only file is still a valid `CODEOWNERS` file.

Ownership is instead recorded in the Rancher UI owners list, which the file
points at:
https://github.com/rancher/dashboard/blob/master/.github/OWNERS.md